### PR TITLE
Fix link to vlingo platform in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 [![Build Status](https://travis-ci.org/vlingo/vlingo-platform.svg?branch=master)](https://travis-ci.org/vlingo/vlingo-platform)
 
-Provides vlingo/platform central "build all" and other control. [Read about the vlingo/platform](https://forcomprehension.com/2017/12/23/vlingo-platform/) and about [its architecture](https://forcomprehension.com/2018/01/24/vlingo-platform-architecture-part1/).
+Provides vlingo/platform central "build all" and other control. [Read about the vlingo/platform and its architecture](https://vlingo.io/).
 
 Use "mvn install" from here with the pom.xml and the entire platform to build.
 

--- a/README.md
+++ b/README.md
@@ -2,7 +2,9 @@
 
 [![Build Status](https://travis-ci.org/vlingo/vlingo-platform.svg?branch=master)](https://travis-ci.org/vlingo/vlingo-platform)
 
-Provides vlingo/platform central "build all" and other control. [Read about the vlingo/platform and its architecture](https://vlingo.io/).
+[Official vlingo/platform website](https://vlingo.io/).
+
+Provides vlingo/platform central "build all" and other control. [Read about the vlingo/platform](https://kalele.io/blog-posts/vlingo-platform/) and about [its architecture](https://kalele.io/blog-posts/vlingo-platform-architecture-part1/).
 
 Use "mvn install" from here with the pom.xml and the entire platform to build.
 


### PR DESCRIPTION
While going through the readme found that the links to platform documentation were broken. Based on what I understood so far I have made them point to vlingo.io.

This platform is an amazing initiative. Went through the examples repo, it looks super cool. I would love to keep contributing.