### PR TITLE
Add a build script for local builds

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,7 +19,35 @@ Prerequisites:
 
 See [RELEASE_HOW_TO](RELEASE_HOW_TO.md) for the release process.
 
-### Build configuration
+### Local builds
+
+To build all libraries locally clone this repository, and run:
+
+```bash
+./build.sh
+```
+
+Note: Windows users can use git-bash to execute the bash script.
+
+To only build selected projects specify them as arguments:
+
+```bash
+./build.sh vlingo-common vlingo-actors
+```
+
+It's also possible to pull without building:
+
+```bash
+./build.sh pull
+```
+
+and build without pulling:
+
+```bash
+./build.sh build
+```
+
+### CI build configuration
 
 - GitHub Organisation secrets
   - `RELEASE_GITHUB_TOKEN` - Use the token on the VLINGO org

--- a/build.sh
+++ b/build.sh
@@ -1,0 +1,159 @@
+#!/bin/bash
+set -eou pipefail
+
+VLINGO_PLATFORM_PATH=$(cd -- "$(dirname "$0")" >/dev/null 2>&1 ; pwd -P)
+VLINGO_HOME=$(cd -- "$VLINGO_PLATFORM_PATH/.." >/dev/null 2>&1 ; pwd -P)
+VLINGO_GITHUB_REPO="https://github.com/vlingo/{PROJECT}.git"
+VLINGO_PROJECTS=($@)
+
+all_projects=(
+  "vlingo-platform"
+  "vlingo-common"
+  "vlingo-actors"
+  "vlingo-streams"
+  "vlingo-streams-tck"
+  "vlingo-wire"
+  "vlingo-cluster"
+  "vlingo-directory"
+  "vlingo-http"
+  "vlingo-auth"
+  "vlingo-symbio"
+  "vlingo-symbio-dynamodb"
+  "vlingo-symbio-geode"
+  "vlingo-symbio-jdbc"
+  "vlingo-lattice"
+  "vlingo-lattice-exchange-camel"
+  "vlingo-lattice-exchange-rabbitmq"
+  "vlingo-schemata"
+  "vlingo-telemetry"
+  "vlingo-xoom"
+  "vlingo-xoom-starter"
+  "vlingo-build-plugins"
+  "vlingo-examples"
+  "vlingo-helloworld"
+)
+
+msg() {
+  echo -e "\x1B[32m[VLINGO BUILD]\x1B[0m $1"
+}
+
+msg_scoped() {
+  echo -e "\x1B[32m[VLINGO BUILD]\x1B[0m\x1B[33m[$1]\x1B[0m $2"
+}
+
+msg_error() {
+  echo -e "\x1B[32m[VLINGO BUILD]\x1B[0m\x1B[31m[Error]\x1B[0m $1"
+  exit 1
+}
+
+_show_config() {
+  msg "VLINGO_PLATFORM_PATH: $VLINGO_PLATFORM_PATH"
+  msg "VLINGO_HOME: $VLINGO_HOME"
+  msg "VLINGO_GITHUB_REPO: $VLINGO_GITHUB_REPO"
+  msg "VLINGO_PROJECTS: $(printf '%s ' ${VLINGO_PROJECTS[@]})"
+}
+
+_last_commit() {
+  project=$1
+  project_path="$VLINGO_HOME/$project"
+  msg_scoped $project "Last commit: $(cd $project_path && git log --oneline -1)"
+}
+
+_clone_or_pull_project() {
+  project=$1
+  project_repo=$(echo $VLINGO_GITHUB_REPO | sed -e 's/{PROJECT}/'$project'/g')
+  project_path="$VLINGO_HOME/$project"
+  if [ -d $project_path ]; then
+    (msg_scoped $project "Pulling in $project_path" && cd $project_path && git pull || msg_error "Failed to pull $project") || exit 255
+  else
+    (msg_scoped $project "Cloning to $project_path" && git clone $project_repo $project_path || msg_error "Failed to clone $project") || exit 255
+  fi
+}
+
+_build_project() {
+  project=$1
+  project_path="$VLINGO_HOME/$project"
+  msg_scoped $project "Building..."
+  cd $project_path && mvn clean install -U && msg_scoped $project "OK" || (msg_error "Failed to build $project" && exit 255)
+}
+
+_clone_or_pull() {
+  projects="$@"
+  printf "%s\0" ${projects[@]} | xargs -0 -I% -n 1 -P8 bash -c '_clone_or_pull_project %'
+  printf "%s\0" ${projects[@]} | xargs -0 -I% -n 1 -P8 bash -c '_last_commit %'
+}
+
+_build() {
+  projects="$@"
+  printf "%s\0" ${projects[@]} | xargs -0 -I% -n 1 bash -c '_build_project %'
+}
+
+_configure() {
+  # exports for xargs/parallel runs
+  export -f msg
+  export -f msg_scoped
+  export -f msg_error
+  export -f _clone_or_pull_project
+  export -f _build_project
+  export -f _last_commit
+  export -p VLINGO_PLATFORM_PATH
+  export -p VLINGO_HOME
+  export -p VLINGO_GITHUB_REPO
+}
+
+help() {
+  echo "Pull and build all, or selected projects:"
+  echo ""
+  echo "  $0 [project...]"
+  echo ""
+  echo "Show help:"
+  echo ""
+  echo "  $0 help"
+  echo ""
+  echo "Pull all or selected projects:"
+  echo ""
+  echo "  $0 pull [project...]]"
+  echo ""
+  echo "Build all or selected projects:"
+  echo ""
+  echo "  $0 build [project...]]"
+}
+
+pull() {
+  _configure
+  _show_config
+  _clone_or_pull ${VLINGO_PROJECTS[@]}
+  msg "Done."
+}
+
+build() {
+  _configure
+  _show_config
+  _build ${VLINGO_PROJECTS[@]}
+  msg "Done."
+}
+
+main() {
+  _configure
+  _show_config
+  _clone_or_pull ${VLINGO_PROJECTS[@]}
+  _build ${VLINGO_PROJECTS[@]}
+  msg "Done."
+}
+
+COMMAND="${1:-"main"}"
+if [[ $COMMAND == vlingo-* ]]; then COMMAND="main"; fi
+
+if [ "$(type -t ${VLINGO_PROJECTS[0]:-""})" == "function" ]; then
+  VLINGO_PROJECTS=("${VLINGO_PROJECTS[@]:1}")
+fi
+
+if [ ${#VLINGO_PROJECTS[@]} -eq 0 ]; then
+  VLINGO_PROJECTS=("${all_projects[@]}")
+fi
+
+if [ "$(type -t $COMMAND)" != "function" ] || [ "${COMMAND:0:1}" == "_" ]; then
+  help
+else
+  $COMMAND
+fi


### PR DESCRIPTION
This PR brings back the ability to build all vlingo projects with one command: `./build.sh`.

Tested on MacOS and Windows (with git-bash).

<img width="1280" alt="image" src="https://user-images.githubusercontent.com/190447/112850514-fd601900-90a1-11eb-9b63-65561d500818.png">


<img width="1124" alt="image" src="https://user-images.githubusercontent.com/190447/112849600-2338ee00-90a1-11eb-841f-dc9bf0604df2.png">
